### PR TITLE
[#5 Prentendard] fix(global.css) : Pretendard 폰트의 적용을 Next.js의 요건에 맞게 변경

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,19 +1,7 @@
 import "@/styles/globals.css";
 import "@/styles/reset.css";
 import type { AppProps } from "next/app";
-import Head from "next/head";
 
 export default function App({ Component, pageProps }: AppProps) {
-  return (
-    <>
-      <Head>
-        <link
-          rel="stylesheet"
-          as="style"
-          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
-        />
-      </Head>
-      <Component {...pageProps} />
-    </>
-  );
+  return <Component {...pageProps} />;
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,13 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="ko">
-      <Head />
+      <Head>
+        <link
+          rel="stylesheet"
+          as="style"
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css"
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -8,7 +8,7 @@ button,
 input,
 h1,
 h2 {
-  font-family: Pretendard;
+  font-family: "Pretendard Variable", Pretendard;
   line-height: normal;
   font-style: normal;
   font-weight: 400;


### PR DESCRIPTION
1. 태그를 이용한 외부 스타일시트를 _app이 아니라 _docx.tsx에서 다룰 수 있도록 수정
2. font name이 "Pretendard Variable"가 아니라 Pretendard로 되어있는 부분 수정